### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = panelmacros
 appName = com.enonic.app.panelmacros
 xpVersion = 8.0.0-B4
-version=1.3.0-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bumps `version` from `1.3.0-SNAPSHOT` to `2.0.0-SNAPSHOT` on master, opening the XP 8 development line.
- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x` so the release tooling recognises both as release branches.
- Maintenance branch `1.x` was created at commit `52538077f4793b243a50e852a33b1a27c2bc8823` (the post-`v1.2.0` SNAPSHOT-bump commit) and continues the XP 7 line at `1.3.0-SNAPSHOT`. A separate PR against `1.x` adds the same workflow change so pushes to that branch are also classified as release builds.

Reference: app-booster (https://github.com/enonic/app-booster — compare `master` and `1.x`).

## Test plan

- [ ] Gradle Build CI run on this PR is green.
- [ ] After merge, `./gradlew clean build` from master succeeds.
- [ ] After the companion `1.x` PR merges, a CI run on `1.x` is classified as a release branch.