### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,0 +1,29 @@
+name: Gradle Build
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
+    steps:
+      - uses: enonic/release-tools/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/enonic-gradle.yml` on the new `1.x` maintenance branch with a `releaseBranch:` block listing both `master` and `1.x`. The release tooling reads `releaseBranch` from the branch's own workflow file, so this is required for pushes to `1.x` to be classified as release-branch builds.
- No version bump and no other changes — the master-only edits (version → `2.0.0-SNAPSHOT`) live in #107.

Maintenance branch `1.x` was created at commit `52538077f4793b243a50e852a33b1a27c2bc8823` (the post-`v1.2.0` SNAPSHOT-bump commit), keeping the XP 7 line at `1.3.0-SNAPSHOT`.

Reference: app-booster (https://github.com/enonic/app-booster — compare `master` and `1.x`).

## Test plan

- [ ] Gradle Build CI run on this PR is green.
- [ ] After merge, a push to `1.x` is classified as a release branch by the build-and-publish action.