### PR TITLE
Bump @enonic-types/* to ^8.0.0-B4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,10 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@enonic-types/core": "^7.16.2",
-        "@enonic-types/global": "^7.16.2",
+        "@enonic-types/core": "^8.0.0-B4",
+        "@enonic-types/global": "^8.0.0-B4",
         "@enonic-types/lib-asset": "^1.0.3",
-        "@enonic-types/lib-portal": "^7.16.2",
+        "@enonic-types/lib-portal": "^8.0.0-B4",
         "@swc/core": "^1.15.32",
         "@types/node": "^25.6.0",
         "tsup": "^8.5.1",
@@ -16,20 +16,18 @@
       }
     },
     "node_modules/@enonic-types/core": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-7.16.2.tgz",
-      "integrity": "sha512-rOhH1Xh2u7Nt/4SYsQbPn8uc/GxM5tciYNYTN8+Grn/YMM71abaBiC/zb9c2KY37lZOoLRWbelZrLp/SpaDtHw==",
-      "dev": true,
-      "license": "Apache-2.0"
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-8.0.0-B4.tgz",
+      "integrity": "sha512-UGq6ixxLMOEQm5NYdjilWUIXugcGiEKAmzuzM1vBCltdJLJfqgJYjVgrziXhbiulpYdxcMoDTe0N8uF7R6j25w==",
+      "dev": true
     },
     "node_modules/@enonic-types/global": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-7.16.2.tgz",
-      "integrity": "sha512-0re7HPPYw/PduCMt/WkgUBVqx9W2gDwwOWyoeM5nrl5GmKRxZLiXu9spWSRz5TAk6wDp2HUBRxbdna9frWueuQ==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-8.0.0-B4.tgz",
+      "integrity": "sha512-CC7OQvPOtxMBfOhnLcDYaMxfdSIaYkbDQ8WnDmXPEPDHMNkraZhirLpdvAnS/7PObS/yEuS94x9GEAqmEd+YFQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "7.16.2"
+        "@enonic-types/core": "8.0.0-B4"
       }
     },
     "node_modules/@enonic-types/lib-asset": {
@@ -41,14 +39,19 @@
         "@enonic-types/core": "^7.14.0"
       }
     },
+    "node_modules/@enonic-types/lib-asset/node_modules/@enonic-types/core": {
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-7.16.3.tgz",
+      "integrity": "sha512-0TbkNHMO9xir/m92RavXL6XIM4L4zA5J4Tk1ettODrX+3YfcoFAXiGlPQanD0k4o3s79D0ZYPw2QKPhA2/OAdw==",
+      "dev": true
+    },
     "node_modules/@enonic-types/lib-portal": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@enonic-types/lib-portal/-/lib-portal-7.16.2.tgz",
-      "integrity": "sha512-Uf9tB2hq2Qb4XVZaycu/ewQClwQp3SESEMMQ2RDDIBv6PJm9/UEeJxW6BIh8F4aOSbLPFiIjFRwlKWi1rwMhHw==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/lib-portal/-/lib-portal-8.0.0-B4.tgz",
+      "integrity": "sha512-QBs9yjIMyLIurd5KiO6q37lxFEhjlsJo5qmgPk0xk3OeDqbI47rQlJnrqUVR/3z5bvbE2Dx6b+RkRp4r2E7Pbg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "7.16.2"
+        "@enonic-types/core": "8.0.0-B4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "devDependencies": {
-    "@enonic-types/core": "^7.16.2",
-    "@enonic-types/global": "^7.16.2",
+    "@enonic-types/core": "^8.0.0-B4",
+    "@enonic-types/global": "^8.0.0-B4",
     "@enonic-types/lib-asset": "^1.0.3",
-    "@enonic-types/lib-portal": "^7.16.2",
+    "@enonic-types/lib-portal": "^8.0.0-B4",
     "@swc/core": "^1.15.32",
     "@types/node": "^25.6.0",
     "tsup": "^8.5.1",


### PR DESCRIPTION
## Summary

- Bumps `@enonic-types/core`, `@enonic-types/global`, and `@enonic-types/lib-portal` from `^7.16.2` to `^8.0.0-B4` to align with XP 8.
- `@enonic-types/lib-asset` is left at `^1.0.3` (no XP-8-aligned release yet); it still pulls in `@enonic-types/core@7.16.3` transitively, which is fine.
- Lockfile refreshed.
- Build is green locally: `./gradlew build` runs `npmBuild` (tsup) + `npmCheck` (`tsc --noEmit -p ./tsconfig.xp.nashorn.json`) with no TS errors — no XP 8 type changes affect this codebase's call sites.

Reference: enonic/doc-code@967803a

## Test plan

- [x] `npm install` refreshes lockfile
- [x] `npm run check` (tsc --noEmit) passes
- [x] `npm run build` (tsup) passes
- [x] `./gradlew build` passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)