### PR TITLE
Migrate to lib-asset #111

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,13 +8,14 @@ plugins {
 dependencies {
     include xplibs.io
     include xplibs.portal
-    include 'com.enonic.lib:lib-asset:1.0.3'
+    include 'com.enonic.lib:lib-asset:2.0.0-SNAPSHOT'
 }
 
 repositories {
     mavenLocal()
     mavenCentral()
     xp.enonicRepo()
+    xp.enonicRepo('dev')
 }
 
 node {

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -1,1 +1,3 @@
 kind: "Site"
+apis:
+  - "asset"


### PR DESCRIPTION
## Summary

`portal.assetUrl` is `@deprecated` in lib-portal. This PR completes the migration to **lib-asset** for `app-panel-macros` on XP 8.

The TypeScript source has been calling `assetUrl` from `/lib/enonic/asset` since `0d7bd46` (Dec 2024, "Fix #27 Use lib-asset 1.0.1"), but two pieces were missing under XP 8:

- `build.gradle` still pulled the XP-7 line of lib-asset (`1.0.3`). Bumped to `2.0.0-SNAPSHOT` (the XP-8 line) and added `xp.enonicRepo('dev')` so the SNAPSHOT resolves.
- `src/main/resources/cms/site.yaml` did not declare `apis: ["asset"]`. Under XP 8 lib-asset is a Universal API and must be mounted on the consuming descriptor — without it, asset URLs 404 with "API [com.enonic.app.panelmacros:asset] is not mounted".

No source change was needed in `lib/panel-common.ts`.

Closes #111

## Files touched

- `build.gradle` — lib-asset `1.0.3` → `2.0.0-SNAPSHOT`, added `xp.enonicRepo('dev')`.
- `src/main/resources/cms/site.yaml` — added `apis: ["asset"]`.

## Test plan

E2E inside `claude-dev` against XP `8.0.0-SNAPSHOT` (xp-distro local install in `/tmp/xp-e2e-*`).

- [x] `./gradlew build --refresh-dependencies` — BUILD SUCCESSFUL.
- [x] Bundle loads: `Started application com.enonic.app.panelmacros bundle 117` in `server.log`.
- [x] No fatal startup errors attributable to this app (filtered `ERROR|Exception|NoSuchMethod|ClassNotFound`).
- [x] lib-asset 2.0.0-SNAPSHOT bundled in the jar: `apis/asset/asset.js`, `apis/asset/asset.yaml`, `apis/asset/requestHandler.js` present.
- [x] Site descriptor in the jar has the registration: `unzip -p panelmacros.jar cms/site.yaml` → `kind: "Site"\napis:\n  - "asset"`.
- [x] Asset API mounted in Site context (bootstrapped a CMS repo + `default` project + `/e2e` Site with `applicationKey: com.enonic.app.panelmacros`):
  ```
  $ curl -i 'http://localhost:8080/site/default/master/e2e/_/com.enonic.app.panelmacros:asset/<fp>/css/panel.css'
  HTTP/1.1 200 OK
  Content-Type: text/css
  Content-Length: 2957
  ```
  This is the exact URL pattern that `assetUrl({path: 'css/panel.css'})` in `lib/panel-common.ts` emits when a panel macro renders in a site context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)