### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 dependencies {
     include xplibs.io
     include xplibs.portal
-    include 'com.enonic.lib:lib-asset:2.0.0-SNAPSHOT'
+    include libs.lib.asset
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+asset = "2.0.0-SNAPSHOT"
+
+[libraries]
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }


### PR DESCRIPTION
## Summary

Move the single inline-versioned dependency (`com.enonic.lib:lib-asset:2.0.0-SNAPSHOT`) into a new `gradle/libs.versions.toml` so this repo matches the catalog style already adopted across roughly half of the IdeaProjects tree (`app-features`, `lib-explorer`, etc.). Pure pin-for-pin migration — no version bumps.

## Conventions adopted

- Version keys: short, lowercase, hyphen-separated (`asset`).
- Library keys: hyphen-separated with the `lib-` prefix matching the artifact name (`lib-asset`).
- `[versions]` and `[libraries]` sorted alphabetically (only one entry here, but the order is set up for future additions).
- `xpVersion` left in `gradle.properties` — the rest of the toolchain expects it there.
- `xplibs.*` accessors left untouched — those come from the XP gradle plugin, not this repo's catalog.
- No `[plugins]` block — plugin versions were not catalogged inline in any meaningful way.

## New catalog content

```toml
[versions]
asset = "2.0.0-SNAPSHOT"

[libraries]
lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
```

## Verification

- `./gradlew build --refresh-dependencies` → `BUILD SUCCESSFUL`
- `./gradlew dependencies --configuration runtimeClasspath` byte-identical before/after the change.

## Test plan

- [ ] CI build passes
- [ ] Resolved `runtimeClasspath` unchanged (already confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)